### PR TITLE
Update scrolled_mobile.html

### DIFF
--- a/TestPages/DynamicResolution/scrolled_mobile.html
+++ b/TestPages/DynamicResolution/scrolled_mobile.html
@@ -80,10 +80,15 @@
       oH.innerHTML = window.outerHeight + " px";
       iW.innerHTML = window.innerWidth + " px";
       iH.innerHTML = window.innerHeight + " px";
-      sW.innerHTML = document.documentElement.scrollWidth + " px";
+      var saveSw = document.documentElement.scrollWidth;
+      sW.innerHTML = saveSw + " px";
       sH.innerHTML = document.documentElement.scrollHeight + " px";
       cW.innerHTML = document.documentElement.clientWidth + " px";
       cH.innerHTML = document.documentElement.clientHeight + " px";
+      // recheck the final 'scrollWidth' to ensure it was not changed 
+      if(saveSw !== document.documentElement.scrollWidth){
+        sW.innerHTML = document.documentElement.scrollWidth + " px";
+      }
     }
     updateData();
     window.addEventListener("resize", () => {


### PR DESCRIPTION
The issue is relevant for cases of narrow screens (e.g. mobile), it causes the value of `documentElement.scrollWidth` to be wrong since the code of calculation and placement (aka: `innerHTML`) is actually changing the width by itself. 
This fix makes sure to set the **actual width value** in case the firstly calculated width is not the actual width.
re-calling the method `updateData()` twice will also result the correct width. 
